### PR TITLE
Refactors

### DIFF
--- a/src/edu/toronto/cs/xcurator/generator/BasicSchemaExtraction.java
+++ b/src/edu/toronto/cs/xcurator/generator/BasicSchemaExtraction.java
@@ -1,0 +1,324 @@
+package edu.toronto.cs.xcurator.generator;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.xpath.XPathExpressionException;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import edu.toronto.cs.xcurator.model.Attribute;
+import edu.toronto.cs.xcurator.model.AttributeInstance;
+import edu.toronto.cs.xcurator.model.OntologyLink;
+import edu.toronto.cs.xcurator.model.Relation;
+import edu.toronto.cs.xcurator.model.RelationInstance;
+import edu.toronto.cs.xcurator.model.Schema;
+import edu.toronto.cs.xcurator.model.SchemaInstance;
+import edu.toronto.cs.xml2rdf.mapping.generator.SchemaException;
+import edu.toronto.cs.xml2rdf.xml.XMLUtils;
+
+public class BasicSchemaExtraction implements MappingStep {
+  private final int maxElements;
+
+  /**
+   * @param maxElements The maximum number of elements to process from the
+   *    source document.
+   */
+  public BasicSchemaExtraction(int maxElements) {
+    this.maxElements = maxElements;
+  }
+
+  public BasicSchemaExtraction() {
+    this(-1);
+  }
+
+  @Override
+  public void process(Element root, Map<String, Schema> schemas) {
+    // The organization of the XML files should have "clinical_studies" as the
+    // very root document element (which is passed in as rootDoc), with many
+    // "clinical_study" child nodes, which is the children variable below.
+    NodeList children = root.getChildNodes();
+    System.out.println(children.getLength());
+
+    // Step 1. Merge the child element nodes and their associated schemas
+    // Iterate through all child nodes or up to the maximum number specified,
+    // and process (merge) ONLY child nodes that are elements.
+    for (int i = 0; i < children.getLength() &&
+        (maxElements == -1 || i < maxElements); i++) {
+      if (children.item(i) instanceof Element) {
+        // Get the child element node.
+        Element child = (Element) children.item(i);
+        String name = child.getNodeName();
+        // Create a schema for this child element node if one with the same node
+        // name does not exist. Consequently, there will be only one schema for
+        // each unique node name. The path of the schema is the ABSOLUTE path to
+        // the child element node, starting with "/" and the root element node
+        // name, such as "/clinical_studies/clinical_study".
+        Schema schema = schemas.get(name);
+
+        if (schema == null) {
+          // Eric: What if child nodes have the same name but at different
+          // layers of the XML file and thus different path? Only the first path
+          // is used?
+          schema = new Schema(null, child, "/" + root.getNodeName() + "/" +
+              name);
+          schemas.put(name, schema);
+        }
+
+        // Merge the child element node with its schema, that is, the schema of
+        // the same name.
+        try {
+          mergeWithSchema(child, schema, schemas);
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+
+  private SchemaInstance mergeWithSchema(Element element, Schema schema,
+      Map<String, Schema> schemas)
+      throws SchemaException, XPathExpressionException {
+    // Cache the instance.
+    SchemaInstance instance = createSchemaInstance(element, schema);
+
+    // Set the schema name, if null, to the name of the element;
+    // or check if the two names are the same, as they should be
+    // Eric: I believe this is unnecessary and should be removed
+    String schemaName = schema.getName();
+    if (schemaName == null) {
+      schema.setName(element.getNodeName());
+    } else {
+      if (!schema.getName().equals(element.getNodeName())) {
+        throw new SchemaException("Schema element names do not match.");
+      }
+    }
+
+    // Never merge leaf element nodes.
+    //
+    // Eric: Technically, this "if statement" will always be true because
+    // if the element if a leaf, then "mergeWithSchema" function will never
+    // be called on this leaf element in the first place
+    if (!XMLUtils.isLeaf(element)) {
+
+      // Get all the (immediate next level) child nodes of the given element node
+      NodeList children = element.getChildNodes();
+
+      // Iterate through all child nodes, but process
+      // ONLY those that are elements
+      for (int i = 0; i < children.getLength(); i++) {
+        if (children.item(i) instanceof Element) {
+
+          // Process child element node that is NOT a leaf element node.
+          if (!XMLUtils.isLeaf(children.item(i))) {
+
+            // Get the non-leaf child element node, which means it has
+            // leaf (and possibly non-leaf) child element nodes under it
+            Element child = (Element) children.item(i);
+
+            // The boolean value to indicate if a previous instance of this
+            // non-leaf child element with the same name has already been
+            // processed/merged.
+            boolean found = false;
+
+            // Find out if this non-leaf child element already exists
+            // in parent element's relations, meaning that a previous
+            // instance of the non-leaf child element with the same name
+            // has already been processed and put into the relations of
+            // the parent element.
+            //
+            // If so, merge this instance of the non-leaf child element
+            // with the already consolidated associated schema, during
+            // which new relations or attributes might be added to this
+            // schema
+            for (Relation childRelation : schema.getRelations()) {
+              if (childRelation.getName().equals(child.getNodeName())) {
+                SchemaInstance childInstance =
+                    mergeWithSchema(child, childRelation.getSchema(), schemas);
+                createRelationInstnace(childRelation, instance, childInstance);
+                found = true;
+                break;
+              }
+            }
+
+            // This is the first encounter of the non-leaf child element
+            // with this node name
+            if (!found) {
+
+              // Get the name of the non-leaf child element node
+              String name = child.getNodeName();
+              // Create the path, which is the ABSOLUTE path to this
+              // non-leaf child element node, starting with "/"
+              String path = schema.getPath() + "/" + name;
+
+              // Create a schema for this non-leaf child element node,
+              // if none exists yet
+              Schema childSchema = schemas.get(name);
+              if (childSchema == null) {
+                // Eric: Why not set the parent to the current schema?
+                childSchema = new Schema(null, child, path);
+                schemas.put(child.getNodeName(), childSchema);
+              }
+
+              // Merge this non-leaf child element node first before
+              // further processing this node
+              SchemaInstance childInstance = mergeWithSchema(child, childSchema,
+                  schemas);
+
+              // Create the lookupKeys for the creation of relation later
+              // This is essentially a list of all leaf elements that
+              // exist under the current child node
+              Set<Attribute> lookupKeys = new HashSet<Attribute>();
+
+              // Get the list of RELATIVE path to all leaf element nodes
+              // of the current non-leaf child element node, with path
+              // starting with the name of the current non-leaf child
+              // element node (and not "/"), and ending with the name
+              // of the leaf element nodes
+              List<String> leaves = XMLUtils.getAllLeaves(child);
+
+              // Iterate through all paths to the leaf element nodes
+              for (String leafPath: leaves) {
+
+                // Get the name of the current LEAF element node
+                int lastNodeIndex = leafPath.lastIndexOf('/');
+                String lastNodeName = leafPath.substring(lastNodeIndex + 1);
+
+                // Create leafName by simply replacing all "/" with "."
+                String leafName = leafPath.replace('/', '.');
+
+                // Append ".name" to the end of leafName if the current
+                // leaf element node has been promoted and has an
+                // OntologyLink schema associated with it
+                //
+                // Eric: Is it correct to say that the ONLY case where
+                // lastNodeSchema is NOT null is when the child node has
+                // been promoted, which means lastNodeSchema is ALWAYS
+                // an OntologyLink schema?
+                Schema lastNodeSchema = schemas.get(lastNodeName);
+                if (lastNodeSchema instanceof OntologyLink) {
+                  // Eric: Why ".name"? What's the meaning behind this?
+                  leafName += ".name";
+                }
+
+                // Create leafPath through removing the name of the parent non-leaf
+                // element node at the beginning, along with the "/", and then append
+                // "/text()" at the end of the leafPath.
+                //
+                // This is essentially the RELATIVE path to the TEXT VALUE of the
+                // current leaf element node under the parent non-leaf element node,
+                // and this path will be understood correctly by XPath
+                leafPath = leafPath.replaceAll("^" + child.getNodeName() + "/?", "");
+                // Eric: Why would leafPath ever be empty anyways? It must at least
+                // contain the name of the LAEF node.
+                leafPath = leafPath.length() > 0 ? leafPath + "/text()" : "text()";
+
+                // Create an entry to the lookupKeys, which keeps track of the parent
+                // non-leaf element node's schema, the name and the RELATIVE path to
+                // all the TEXT VALUES of the leaf element nodes under it, and whether
+                // these element nodes are keys or not
+                //
+                // Eric: I'm still unclear about the answer to the email question
+                // regarding the lookupKeys (Question 1.2).
+                lookupKeys.add(new Attribute(schema, leafName, leafPath, false));
+              }
+
+              // Eric: Why is path (the third parameter) set to name?
+              // Set the parent-child (schema-childSchema) relation, with lookupKeys essentially
+              // a list of LEAF nodes of the child (childSchema) and their parent is set to
+              // schema
+              // One can think of the path to the childSchema as schema.getPath() + "/" + name
+              // (name is the name of the childSchema)
+              Relation relation = new Relation(schema, name, name, childSchema, lookupKeys);
+              schema.addRelation(relation);
+              createRelationInstnace(relation, instance, childInstance);
+            }
+          }
+
+          // Process child element node that IS INDEED a leaf element node
+          else {
+
+            // Get the leaf child element and its name
+            Element child = (Element) children.item(i);
+            String name = child.getNodeName();
+
+            // Get the ABSOLUTE path to the leaf child element,
+            // starting with "/"
+            String path = schema.getPath() + "/" + name;
+
+            // Find out if a previous instance of the leaf child element
+            // with the same name has already been added to the attributes
+            // or relations. Since the leaf child element has no children,
+            // the previous instance will be exactly the same as the current
+            // instance (structure-wise), the current instance does not need
+            // to be processed anymore.
+            boolean found = false;
+
+            for (Attribute childAttribute : schema.getAttributes()) {
+              if (childAttribute.getName().equals(child.getNodeName())) {
+                found = true;
+                break;
+              }
+            }
+
+            for (Relation childRelation : schema.getRelations()) {
+              if (childRelation.getSchema() instanceof OntologyLink
+                  && childRelation.getName().equals(child.getNodeName())) {
+                found = true;
+                break;
+              }
+            }
+
+            // If no previous instance has found, which means this is the first
+            // encounter of the leaf child node with this name
+            if (!found) {
+              // The attribute is created with path being the ABSOLUTE path
+              // to the TEXT VALUE of the leaf child node
+              //
+              // Eric: Why use "setPath" when name and path can be set when
+              // the attribute is initialized
+
+              Attribute attribute = new Attribute(schema, name, path, false);
+              attribute.setName(child.getNodeName());
+              attribute.setPath(child.getNodeName() + "/text()");
+
+              schema.addAttribute(attribute);
+              createAttributeInstance(attribute, instance, child);
+            }
+          }
+        }
+      }
+    }
+    return instance;
+  }
+
+  private SchemaInstance createSchemaInstance(Element element, Schema schema) {
+    SchemaInstance instance = null;
+    try {
+      instance = new SchemaInstance(element);
+      schema.addInstace(instance);
+    } catch (IOException e) {}
+    return instance;
+  }
+
+  private AttributeInstance createAttributeInstance(Attribute attribute,
+      SchemaInstance schemaInstance, Element attributeElement) {
+    AttributeInstance instance = null;
+    try {
+      instance = new AttributeInstance(schemaInstance, attributeElement);
+      attribute.addInstance(instance);
+    } catch (IOException e) {}
+    return instance;
+  }
+
+  private RelationInstance createRelationInstnace(Relation relation,
+      SchemaInstance from, SchemaInstance to) {
+    RelationInstance instance = new RelationInstance(from, to);
+    relation.addInstance(instance);
+    return instance;
+  }
+}

--- a/src/edu/toronto/cs/xcurator/generator/MappingGenerator.java
+++ b/src/edu/toronto/cs/xcurator/generator/MappingGenerator.java
@@ -1,0 +1,250 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.generator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import edu.toronto.cs.xcurator.model.Attribute;
+import edu.toronto.cs.xcurator.model.OntologyLink;
+import edu.toronto.cs.xcurator.model.Relation;
+import edu.toronto.cs.xcurator.model.Schema;
+import edu.toronto.cs.xml2rdf.mapping.Entity;
+import edu.toronto.cs.xml2rdf.opencyc.OpenCycOntology;
+import edu.toronto.cs.xml2rdf.utils.DependencyDAG;
+import edu.toronto.cs.xml2rdf.utils.LogUtils;
+
+/**
+ * A mapping generator is a pipeline of mapping steps that extracts the mapping
+ * schema for a semi-structured data. Note that the generator does not have any
+ * transformation logic, and the logic is implemented in the steps.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public final class MappingGenerator {
+  public MappingGenerator() {
+    pipeline = new ArrayList<MappingStep>();
+  }
+
+  /**
+   * Generates the mapping.
+   *
+   * @param root The root element of the source document.
+   * @param typePrefix The type prefix for the generated mappings.
+   * @return The XML document representing the mapping.
+   */
+  public Document generateMapping(Element root, String typePrefix) {
+    Map<String, Schema> schemas = new HashMap<String, Schema>();
+    for (MappingStep  step : pipeline) {
+      step.process(root, schemas);
+    }
+    return serializeSchemas(schemas, typePrefix);
+  }
+
+  /**
+   * Adds a mapping step to the generator. This step will be appended to the
+   * existing pipeline of steps.
+   *
+   * @param step The mapping step.
+   */
+  public MappingGenerator addStep(MappingStep step) {
+    pipeline.add(step);
+    return this;
+  }
+
+  /**
+   * Serializes generated schemas into an XML document.
+   *
+   * @param schemas The map of schemas.
+   * @param typePrefix The URI type prefix.
+   * @return The serialized XML document.
+   */
+  private Document serializeSchemas(Map<String, Schema> schemas,
+      String typePrefix) {
+    DependencyDAG<Schema> dependecyDAG = new DependencyDAG<Schema>();
+
+    for (Schema schema : schemas.values()) {
+      dependecyDAG.addNode(schema);
+      for (Relation rel : schema.getRelations()) {
+        if (!schemas.containsKey(rel.getSchema())) {
+          LogUtils.error(MappingGenerator.class,
+              rel.getSchema() + " Does not exist: " + rel);
+        }
+      }
+    }
+
+    for (Schema schema : schemas.values()) {
+      for (Relation rel : schema.getRelations()) {
+        dependecyDAG.addDependency(schema, rel.getSchema());
+      }
+    }
+
+    Document mappingRoot = null;
+    try {
+      mappingRoot = DocumentBuilderFactory.newInstance()
+          .newDocumentBuilder().newDocument();
+
+      Element rootElement = mappingRoot.createElementNS(
+          "http://www.cs.toronto.edu/xml2rdf/mapping/v1", "mapping");
+      mappingRoot.appendChild(rootElement);
+
+      while (dependecyDAG.size() != 0) {
+        Schema schema = dependecyDAG.removeElementWithNoDependency();
+        addSchema(schema, mappingRoot, typePrefix);
+      }
+
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    }
+
+    return mappingRoot;
+  }
+
+  /**
+   * Adds an schema the generated mapping document.
+   *
+   * @param schema The schema.
+   * @param mappingRoot The root of XML document.
+   * @param path
+   * @param typePrefix
+   */
+  private void addSchema(Schema schema, Document mappingRoot,
+      String typePrefix) {
+    Element schemaElement = mappingRoot.createElementNS(
+        "http://www.cs.toronto.edu/xml2rdf/mapping/v1", "entity");
+    schemaElement.setAttribute("path", schema.getPath());
+    schemaElement.setAttribute("type", typePrefix
+        + schema.getName());
+    mappingRoot.getDocumentElement().appendChild(schemaElement);
+    Element idElement = mappingRoot.createElementNS(
+        "http://www.cs.toronto.edu/xml2rdf/mapping/v1", "id");
+    idElement.setTextContent(typePrefix + "${" + Entity.AUTO_GENERATED + "}");
+    schemaElement.appendChild(idElement);
+
+    if (schema instanceof OntologyLink) {
+      Element attributeElement = mappingRoot.createElementNS(
+          "http://www.cs.toronto.edu/xml2rdf/mapping/v1", "property");
+      attributeElement.setAttribute("path", "text()");
+      attributeElement.setAttribute("name", typePrefix + "name_property");
+      attributeElement.setAttribute("key", "true");
+      schemaElement.appendChild(attributeElement);
+
+
+      for (String ontologyURI : ((OntologyLink) schema).getTypeURIs()) {
+
+        String label = OpenCycOntology.getInstance()
+            .getLabelForResource(ontologyURI);
+
+        Element ontologyElement = mappingRoot.createElementNS(
+            "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+            "ontology-link");
+        ontologyElement.setAttribute("uri", ontologyURI);
+        ontologyElement.setAttribute("label", label);
+        schemaElement.appendChild(ontologyElement);
+      }
+
+    } else {
+      // TODO: reload attributes
+      for (String ontologyURI : schema.getTypeURIs()) {
+        String label =
+            OpenCycOntology.getInstance().getLabelForResource(ontologyURI);
+
+        Element ontologyElement = mappingRoot.createElementNS(
+            "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+            "ontology-link");
+        ontologyElement.setAttribute("uri", ontologyURI);
+        ontologyElement.setAttribute("label", label);
+        schemaElement.appendChild(ontologyElement);
+      }
+
+
+      for (Attribute attribute : schema.getAttributes()) {
+        Element attributeElement = mappingRoot.createElementNS(
+            "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+            "property");
+        attributeElement.setAttribute("path", attribute.getPath());
+        attributeElement.setAttribute("name",
+            typePrefix + attribute.getName() + "_property");
+        attributeElement.setAttribute("key", String.valueOf(attribute.isKey()));
+
+        for (String ontologyURI: attribute.getTypeURIs()) {
+          Element ontologyElement = mappingRoot.createElementNS(
+              "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+              "ontology-link");
+          String label =
+              OpenCycOntology.getInstance().getLabelForResource(ontologyURI);
+
+          ontologyElement.setAttribute("uri", ontologyURI);
+          ontologyElement.setAttribute("label", label);
+          attributeElement.appendChild(ontologyElement);
+        }
+
+        schemaElement.appendChild(attributeElement);
+      }
+
+      for (Relation relation : schema.getRelations()) {
+        Element relationElement = mappingRoot.createElementNS(
+            "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+            "relation");
+        relationElement.setAttribute("path", relation.getPath());
+        relationElement.setAttribute("targetEntity", typePrefix
+            + relation.getSchema().getName());
+        relationElement.setAttribute("name",
+            typePrefix + relation.getName() + "_rel");
+        schemaElement.appendChild(relationElement);
+
+        Element lookupElement = mappingRoot.createElementNS(
+            "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+            "lookupkey");
+
+        for (Attribute attr: relation.getLookupKeys()) {
+          Element targetPropertyElement = mappingRoot.createElementNS(
+              "http://www.cs.toronto.edu/xml2rdf/mapping/v1",
+              "target-property");
+          targetPropertyElement.setAttribute("path", attr.getPath());
+//          String name = attr.getName();
+//          String[] nameSplitted = name.split("\\.");
+//          String newName = nameSplitted[0];
+//          for (int i = 1; i < nameSplitted.length - 1; i++) {
+//            newName += "." + nameSplitted[i] + "_rel";
+//          }
+//
+//          if (nameSplitted.length == 1) {
+//            newName += "_prop";
+//          } else {
+//            newName += nameSplitted[nameSplitted.length - 1] + "_prop";
+//          }
+
+          targetPropertyElement.setAttribute("name",
+              typePrefix + attr.getName());
+          lookupElement.appendChild(targetPropertyElement);
+        }
+
+        relationElement.appendChild(lookupElement);
+      }
+
+    }
+  }
+  private final List<MappingStep> pipeline;
+}

--- a/src/edu/toronto/cs/xcurator/generator/MappingStep.java
+++ b/src/edu/toronto/cs/xcurator/generator/MappingStep.java
@@ -1,0 +1,18 @@
+package edu.toronto.cs.xcurator.generator;
+
+import java.util.Map;
+
+import org.w3c.dom.Element;
+
+import edu.toronto.cs.xcurator.model.Schema;
+
+public interface MappingStep {
+  /**
+   * Processes the map of schemas.
+   *
+   * @param root The XML root element of the source document.
+   * @param schemas The map of processed schemas. Note that the step should only
+   *    modify the schemas map.
+   */
+  void process(Element root, Map<String, Schema> schemas);
+}

--- a/src/edu/toronto/cs/xcurator/model/Attribute.java
+++ b/src/edu/toronto/cs/xcurator/model/Attribute.java
@@ -1,0 +1,140 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents an attribute in a schema.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class Attribute {
+  public Attribute(Schema parent, String name, String path, boolean key) {
+    super();
+    this.name = name;
+    this.path = path;
+    this.parent = parent;
+    this.key = key;
+
+    instanceMap = new HashMap<SchemaInstance, Set<AttributeInstance>>();
+    reverseInstanceMap = new HashMap<String, Set<AttributeInstance>>();
+  }
+
+  public void addInstance(AttributeInstance instance) {
+    Set<AttributeInstance> attributes =
+        instanceMap.get(instance.schemaInstance);
+    if (attributes == null) {
+      attributes = new HashSet<AttributeInstance>();
+      instanceMap.put(instance.schemaInstance, attributes);
+    }
+    attributes.add(instance);
+
+    attributes = reverseInstanceMap.get(instance.content);
+    if (attributes == null) {
+      attributes = new HashSet<AttributeInstance>();
+      reverseInstanceMap.put(instance.content, attributes);
+    }
+    attributes.add(instance);
+  }
+
+  public boolean isOneToOne() {
+    for (Map.Entry<SchemaInstance, Set<AttributeInstance>> entry :
+        instanceMap.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        return false;
+      }
+    }
+
+    for (Map.Entry<String, Set<AttributeInstance>> entry :
+        reverseInstanceMap.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public void setParent(Schema parent) {
+    this.parent = parent;
+  }
+
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+  public String getPath() {
+    return path;
+  }
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public boolean isKey() {
+    return key;
+  }
+
+  public void setKey(boolean key) {
+    this.key = key;
+  }
+
+  public Schema getParent() {
+    return parent;
+  }
+
+  @Override
+  public String toString() {
+    return "A@ " + name;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Attribute) {
+      Attribute attr = (Attribute) obj;
+      return attr.name.equals(this.name) && attr.parent.equals(this.parent) &&
+          attr.path.equals(this.path);
+    }
+    return super.equals(obj);
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  public Set<String> getTypeURIs() {
+    return typeURIs;
+  }
+
+  public void setTypeURIs(Set<String> typeURIs) {
+    this.typeURIs = typeURIs;
+  }
+
+  String name;
+  String path;
+  Schema parent;
+  boolean key;
+
+  Set<String> typeURIs = new HashSet<String>();
+  Map<SchemaInstance, Set<AttributeInstance>> instanceMap;
+  Map<String, Set<AttributeInstance>> reverseInstanceMap;
+}

--- a/src/edu/toronto/cs/xcurator/model/AttributeInstance.java
+++ b/src/edu/toronto/cs/xcurator/model/AttributeInstance.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.io.IOException;
+
+import org.w3c.dom.Element;
+
+import edu.toronto.cs.xml2rdf.xml.XMLUtils;
+
+/**
+ * Represents an instace of an attribute.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class AttributeInstance {
+  public AttributeInstance(SchemaInstance instance, Element element)
+      throws IOException {
+    this(instance, XMLUtils.asString(element));
+  }
+
+  AttributeInstance(SchemaInstance instance, String content) {
+    this.content = content;
+    this.schemaInstance = instance;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof AttributeInstance) {
+      AttributeInstance that = (AttributeInstance) obj;
+      return content.equals(that.content) &&
+          schemaInstance.equals(that.schemaInstance);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return content.hashCode() ^ schemaInstance.hashCode() << 7;
+  }
+
+  @Override
+  public String toString() {
+    return schemaInstance + "::" + content;
+  }
+
+  SchemaInstance schemaInstance;
+  String content;
+}

--- a/src/edu/toronto/cs/xcurator/model/OntologyLink.java
+++ b/src/edu/toronto/cs/xcurator/model/OntologyLink.java
@@ -1,0 +1,34 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.util.Set;
+
+import org.w3c.dom.Element;
+
+/**
+ * OntologyLink is a specific type of schema reprsenting a link to an external
+ * ontology.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class OntologyLink extends Schema {
+  OntologyLink(Schema parent, Element element, String path,
+      Set<String> typeURIs) {
+    super(parent, element, path);
+    this.typeURIs = typeURIs;
+  }
+}

--- a/src/edu/toronto/cs/xcurator/model/Relation.java
+++ b/src/edu/toronto/cs/xcurator/model/Relation.java
@@ -1,0 +1,134 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Represents a relation between two schemas.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class Relation {
+  String name;
+  String path;
+  Schema schema;
+  Schema parent;
+
+  Set<Attribute> lookupKeys;
+  Map<SchemaInstance, Set<RelationInstance>> instanceMap;
+  Map<SchemaInstance, Set<RelationInstance>> reverseInstanceMap;
+
+  public Relation(Schema parent, String name, String path, Schema schema,
+      Set<Attribute> lookupKeys) {
+    super();
+    this.name = name;
+    this.path = path;
+    this.lookupKeys = lookupKeys;
+    instanceMap = new HashMap<SchemaInstance, Set<RelationInstance>>();
+    reverseInstanceMap = new HashMap<SchemaInstance, Set<RelationInstance>>();
+
+    this.setParent(parent);
+    this.setSchema(schema);
+  }
+
+  public void setParent(Schema parent) {
+    // TODO(soheil): We might need to remove it here.
+    this.parent = parent;
+    parent.addRelation(this);
+  }
+
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+  public String getPath() {
+    return path;
+  }
+  public void setPath(String path) {
+    this.path = path;
+  }
+  public Schema getSchema() {
+    return schema;
+  }
+  public void setSchema(Schema schema) {
+    this.schema = schema;
+    schema.addReverseRelation(this);
+  }
+
+  public Set<Attribute> getLookupKeys() {
+    return lookupKeys;
+  }
+
+  @Override
+  public String toString() {
+    return "R@ " + name;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Relation) {
+      Relation relation = (Relation) obj;
+      return relation.name.equals(this.name) &&
+          relation.schema.equals(this.schema);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  public void addInstance(RelationInstance instance) {
+    Set<RelationInstance> relations = instanceMap.get(instance.from);
+    if (relations == null) {
+      relations = new HashSet<RelationInstance>();
+      instanceMap.put(instance.from, relations);
+    }
+    relations.add(instance);
+
+    relations = reverseInstanceMap.get(instance.to);
+    if (relations == null) {
+      relations = new HashSet<RelationInstance>();
+      reverseInstanceMap.put(instance.to, relations);
+    }
+    relations.add(instance);
+  }
+
+  public boolean isOneToOne() {
+    for (Map.Entry<SchemaInstance, Set<RelationInstance>> entry :
+        instanceMap.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        return false;
+      }
+    }
+
+    for (Map.Entry<SchemaInstance, Set<RelationInstance>> entry :
+        reverseInstanceMap.entrySet()) {
+      if (entry.getValue().size() > 1) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/edu/toronto/cs/xcurator/model/RelationInstance.java
+++ b/src/edu/toronto/cs/xcurator/model/RelationInstance.java
@@ -1,0 +1,51 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+/**
+ * Represents an instance of a relation.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class RelationInstance {
+  public RelationInstance(SchemaInstance from, SchemaInstance to) {
+    this.from = from;
+    this.to = to;
+  }
+
+  SchemaInstance from;
+  SchemaInstance to;
+
+  @Override
+  public int hashCode() {
+    return from.hashCode() ^ to.hashCode() << 7;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof RelationInstance) {
+      RelationInstance that = (RelationInstance) obj;
+      return from.equals(that.from) && to.equals(that.to);
+    }
+
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + from + "," + to + ")";
+  }
+}

--- a/src/edu/toronto/cs/xcurator/model/Schema.java
+++ b/src/edu/toronto/cs/xcurator/model/Schema.java
@@ -1,0 +1,152 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.w3c.dom.Element;
+
+/**
+ * Represents a mapped type schema.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class Schema {
+  public Schema(Schema parent, Element element, String path) {
+    attributes = new HashSet<Attribute>();
+    relations = new HashSet<Relation>();
+    reverseRelations = new HashSet<Relation>();
+    instances = new HashSet<SchemaInstance>();
+    this.path = path;
+    this.element = element;
+    this.parent = parent;
+    this.name = element.getNodeName();
+  }
+
+  public Schema(Schema parent, String name, String path) {
+    attributes = new HashSet<Attribute>();
+    relations = new HashSet<Relation>();
+    reverseRelations = new HashSet<Relation>();
+    this.path = path;
+    this.parent = parent;
+    this.name = name;
+  }
+
+  public void addAttribute(Attribute attribute) {
+    attributes.add(attribute);
+  }
+
+  public void addReverseRelation(Relation relation) {
+    reverseRelations.add(relation);
+  }
+
+  public void addRelation(Relation relation) {
+    relations.add(relation);
+  }
+
+  public Set<Relation> getRelations() {
+    return relations;
+  }
+
+  public void setRelations(Set<Relation> relations) {
+    this.relations = relations;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+//  public Element getElement() {
+//    return element;
+//  }
+//
+//  void setElement(Element element) {
+//    this.element = element;
+//  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Set<Attribute> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Set<Attribute> attributes) {
+    this.attributes = attributes;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public String toString() {
+    return "S@ " + name;
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Schema) {
+      Schema schema = (Schema) obj;
+      return name.equals(schema.name);
+    }
+
+    return false;
+  }
+
+  public Set<String> getTypeURIs() {
+    return typeURIs;
+  }
+
+  public void setTypeURIs(Set<String> typeURIs) {
+    this.typeURIs = typeURIs;
+  }
+
+  public void addInstace(SchemaInstance instance) {
+    instances.add(instance);
+  }
+
+  Set<String> typeURIs = new HashSet<String>();
+  Element element;
+
+  String id;
+  String name;
+
+  Set<Attribute> attributes;
+  Set<Relation> relations;
+  Set<Relation> reverseRelations;
+
+  String path;
+
+  Schema parent;
+
+  Set<SchemaInstance> instances;
+}

--- a/src/edu/toronto/cs/xcurator/model/SchemaInstance.java
+++ b/src/edu/toronto/cs/xcurator/model/SchemaInstance.java
@@ -1,0 +1,59 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.model;
+
+import java.io.IOException;
+
+import org.w3c.dom.Element;
+
+import edu.toronto.cs.xml2rdf.xml.XMLUtils;
+
+/**
+ * Represents an instance of a schema.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class SchemaInstance {
+  public SchemaInstance(Element element) throws IOException {
+    this(XMLUtils.asString(element));
+  }
+
+  SchemaInstance(String content) {
+    this.content = content;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof SchemaInstance) {
+      SchemaInstance that = (SchemaInstance) obj;
+      return content.equals(that.content);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return content.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return content;
+  }
+
+  String content;
+}

--- a/test/edu/toronto/cs/xcurator/generator/MappingGeneratorTest.java
+++ b/test/edu/toronto/cs/xcurator/generator/MappingGeneratorTest.java
@@ -1,0 +1,79 @@
+/*
+ *    Copyright (c) 2013, University of Toronto.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *    not use this file except in compliance with the License. You may obtain
+ *    a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+package edu.toronto.cs.xcurator.generator;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import junit.framework.TestCase;
+
+import org.apache.xml.serialize.OutputFormat;
+import org.apache.xml.serialize.XMLSerializer;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import edu.toronto.cs.xcurator.generator.BasicSchemaExtraction;
+import edu.toronto.cs.xcurator.generator.MappingGenerator;
+import edu.toronto.cs.xml2rdf.utils.LogUtils;
+import edu.toronto.cs.xml2rdf.xml.XMLUtils;
+
+/**
+ * The main test case for xCurator v2.0.
+ *
+ * @author Soheil Hassas Yeganeh <soheil@cs.toronto.edu>
+ */
+public class MappingGeneratorTest extends TestCase {
+  public void testBasicStep() throws ParserConfigurationException, SAXException,
+      IOException {
+    LogUtils.shutup();
+
+    int[] max = new int[] { 10 }; // 10, 25, 50, 100, 250, 500, 1000 };
+
+    for (int m: max) {
+
+      System.out.println("\n\n  >> Running experiments for sample size: " + m +
+          " << \n\n");
+
+      PrintStream nout = new PrintStream("out.tmp");
+
+      Document rootDoc = XMLUtils.attributize(XMLUtils.parse(
+          MappingGeneratorTest.class.getResourceAsStream(
+              "/clinicaltrials/data/content.xml"), m));
+      OutputFormat format = new OutputFormat(rootDoc);
+      format.setLineWidth(65);
+      format.setIndenting(true);
+      format.setIndent(2);
+      XMLSerializer serializer = new XMLSerializer (
+          nout, format);
+          //System.out, format);
+      serializer.asDOMSerializer();
+      serializer.serialize(rootDoc);
+
+      Document doc = new MappingGenerator()
+          .addStep(new BasicSchemaExtraction(m))
+          .generateMapping(rootDoc.getDocumentElement(),
+              "http://www.linkedct.org/0.1#");
+
+      serializer = new XMLSerializer(
+          new FileOutputStream("output/new/output.ct.1." + m + ".xml"), format);
+      serializer.asDOMSerializer();
+      serializer.serialize(doc);
+    }
+  }
+}


### PR DESCRIPTION
Refactors the schema generator into a generic pipeline of mapping steps
can be configured at runtime. This commit contains only the basic schema
extraction step as a proof of concept.

In the new version the generator will be called as:

``` java
new MappingGenerator()
    .addStep(new BasicSchemaExtraction(1000))
    ...
    .generateMapping(rootDoc.getDocumentElement(), "http://www.linkedct.org/0.1#");
```
